### PR TITLE
Add tests for zipTaskIfNotExist

### DIFF
--- a/app/services/FileSystem.scala
+++ b/app/services/FileSystem.scala
@@ -46,7 +46,7 @@ class FileSystem () {
     *
     * @example
     * fs.zipDirIfNotExist("github", "triggers", "list_webhooks")
-    * // creates a zip file under tasks/github/list_webhooks/list_webhooks.zip
+    * // creates a zip file under tasks/github/triggers/list_webhooks/list_webhooks.zip
     *
     * @param appName
     * @param taskType

--- a/test/unit/services/FileSystemSpec.scala
+++ b/test/unit/services/FileSystemSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito.when
 import org.mockito.Mockito._
 import services.FileSystem
+import scala.reflect.io.Path
+
 
 /**
   * Unit tests can run without a full Play application.
@@ -36,15 +38,87 @@ class FileSystemSpec extends PlaySpec {
     }
 
     "zipTaskIfNotExist" should {
-      "return true without errors" in {
 
-        /* val fs = new FileSystem {
-          override val File = FakeFile
-        }
+      val pwd = System.getProperty("user.dir")
 
-        val result = fs.zipTaskIfNotExist("github", "hello", "zz") */
-        // TODO: Finish implementing it
-        true must equal(true)
+      val appName = "github"
+      val taskType = "hello"
+      val taskName = "zz"
+
+      val testDir = new java.io.File(s"$pwd/tasks/$appName/$taskType/$taskName")
+
+      "create the zip" in {
+        // setup: create test dir with files to zip
+        val testPath = createTestDirWithFiles(testDir)
+
+        val fs = new FileSystem()
+
+        val result = fs.zipTaskIfNotExist(appName, taskType, taskName)
+
+        val expectedZipPath = testPath.resolve(s"$taskName.zip")
+
+        expectedZipPath.toFile.exists must equal(true)
+
+        // file size
+        expectedZipPath.toFile.length().toInt must be > 0
+
+        result must equal(true)
+
+        // teardown
+        deleteDir(testPath.getParent.toFile)
+      }
+
+
+      "create the zip when already exists and force=true" in {
+        // setup: create test dir already containing zip
+        val testPath = createTestDirWithFiles(testDir)
+        testPath.resolve(s"$taskName.zip").toFile.createNewFile()
+
+        val fs = new FileSystem()
+
+        fs.zipTaskIfNotExist(appName, taskType, taskName, force=true)
+
+        val expectedZipPath = testPath.resolve(s"$taskName.zip")
+
+        // file size should be Not be zero since the empty zip replaced
+        expectedZipPath.toFile.length().toInt must be > 0
+
+        // teardown
+        deleteDir(testPath.getParent.toFile)
+      }
+
+
+      "NOT create the zip when already exists and force=false" in {
+        // setup: create test dir already containing zip
+        val testPath = createTestDirWithFiles(testDir)
+        testPath.resolve(s"$taskName.zip").toFile.createNewFile()
+
+        val fs = new FileSystem()
+
+        fs.zipTaskIfNotExist(appName, taskType, taskName, force=false)
+
+        val expectedZipPath = testPath.resolve(s"$taskName.zip")
+
+        // file size should be zero since the empty zip already existed
+        expectedZipPath.toFile.length() must equal(0)
+
+        // teardown
+        deleteDir(testPath.getParent.toFile)
+      }
+    }
+
+    def createTestDirWithFiles(testDir: java.io.File): java.nio.file.Path = {
+      testDir.mkdirs()
+      val testPath = testDir.toPath
+      java.nio.file.Files.write(testPath.resolve("test-file-1.txt"), "hello".getBytes)
+      java.nio.file.Files.write(testPath.resolve("test-file-2.txt"), "world".getBytes)
+      testPath
+    }
+
+    def deleteDir(file: java.io.File): Unit = {
+      if (file.exists()) {
+        Option(file.listFiles()).map(_.foreach(deleteDir(_)))
+        file.delete()
       }
     }
 


### PR DESCRIPTION
Avoided depending on betterFiles by using `java.io` and `java.nio` so that you are not relying on the dependency in tests and for better confidence that betterFiles working as expected.

To improve this I would move it into an integration tests directory that would be run independently of unit tests.

Fixes #4 